### PR TITLE
 Fix build error when LIBTAS_HAS_XINPUT not defined 

### DIFF
--- a/32bit.toolchain.cmake
+++ b/32bit.toolchain.cmake
@@ -1,8 +1,7 @@
 set(CMAKE_SYSTEM_NAME Linux)
 
-set(CMAKE_C_COMPILER gcc)
+set(CMAKE_C_COMPILER i686-linux-gnu-gcc)
 set(CMAKE_C_FLAGS -m32)
-set(CMAKE_CXX_COMPILER g++)
+set(CMAKE_CXX_COMPILER i686-linux-gnu-g++)
 set(CMAKE_CXX_FLAGS -m32)
 set(CMAKE_SYSTEM_PROCESSOR "i686")
-

--- a/README.md
+++ b/README.md
@@ -55,7 +55,14 @@ If you want to manually enable/disable a feature, you must add just after the `c
 
 - `-DENABLE_HUD=ON/OFF`: enable/disable displaying informations on the game screen
 
-Be careful that you must compile your code in the same arch as the game. If you have an amd64 system and you only have access to a i386 game, the easiest way is to build a virtual machine with a i386 system. You could also try to cross-compile the code to i386. To do that, use the provided toolchain file as followed: `cmake -DCMAKE_TOOLCHAIN_FILE=../32bit.toolchain.cmake ..`. However, many users failed to do this due to some libraries that don't like this operation.
+Be careful that you must compile your code in the same arch as the game. If you have an amd64 system and you only have access to a i386 game, the easiest way is to build a virtual machine with a i386 system. 
+
+#### Cross-Compiling
+Alternatively, you could also try to cross-compile the code to i386. To do that, you will need to use the provided toolchain file as when running the cmake command: `cmake -DCMAKE_TOOLCHAIN_FILE=../32bit.toolchain.cmake ..`. 
+
+You will also need to have the i686 cross-compiler set up beforehand. On Ubuntu, for example, this can be obtained with `apt-get install gcc-i686-linux-gnu g++-i686-linux-gnu cpp-i686-linux-gnu binutils-i686-linux-gnu libc6-dev-i386-cross` .
+
+When installing the dependencies for cross-compilation, it's important to ensure that all of them have their 32-bit versions installed. On APT based systems such as Ubuntu, this is accomplished by appending `:i386` to the package name, for example `apt-get libswresample-dev` would become `apt-get libswresample-dev:i386` .
 
 ## Run
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ If you want to manually enable/disable a feature, you must add just after the `c
 
 - `-DENABLE_HUD=ON/OFF`: enable/disable displaying informations on the game screen
 
-Be careful that you must compile your code in the same arch as the game. If you have an amd64 system and you only have access to a i386 game, the easiest way is to build a virtual machine with a i386 system. 
+Be careful that you must compile your code in the same arch as the game. If you have an amd64 system and i386-only game, the easiest way is to build a virtual machine with a i386 system. 
 
 #### Cross-Compiling
-Alternatively, you could also try to cross-compile the code to i386. To do that, you will need to use the provided toolchain file as when running the cmake command: `cmake -DCMAKE_TOOLCHAIN_FILE=../32bit.toolchain.cmake ..`. 
+Instead of using a virtual machine, you could also try cross-compile the code to i386 if you need a 32-bit version. To do that, you will need to use the provided toolchain file as when running the cmake command: `cmake -DCMAKE_TOOLCHAIN_FILE=../32bit.toolchain.cmake ..`. 
 
 You will also need to have the i686 cross-compiler set up beforehand. On Ubuntu, for example, this can be obtained with `apt-get install gcc-i686-linux-gnu g++-i686-linux-gnu cpp-i686-linux-gnu binutils-i686-linux-gnu libc6-dev-i386-cross` .
 

--- a/src/library/XlibEventQueue.cpp
+++ b/src/library/XlibEventQueue.cpp
@@ -205,6 +205,7 @@ void XlibEventQueue::delayedDeleteCookie(XEvent* event)
     else {
         cookieData = nullptr;
     }
-}
 #endif
+}
+
 }


### PR DESCRIPTION
When LIBTAS_HAS_XINPUT isn't defined, the build failed due to mismatched brackets. 

I initially bumped into this while trying to figure out how to cross-compile the 32-bit version on my 64-bit system without resorting to a VM. 

Apparently my attempt at a 32-bit build exposed it due me to apparently not having the 32-bit version of Xinput installed. Which caused the contents of the ifdef block to be omitted, which caused a mismatched bracket to fail the build.

It looks like the idea here is that if we don't have Xinput, then the function becomes a no-op in the form of an empty `{}` block. But the closing bracket was on the wrong side of the `#endif` for that to work. The confusion is probably related to that other `}` bracket outside the `ifdef` block, but that thing is actually to close the `namespace` block that starts all the way up on line 27.